### PR TITLE
Qiita api

### DIFF
--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -13,6 +13,12 @@ class LineBotController < ApplicationController
           http.use_ssl = (uri.scheme == 'https')
 
           request = Net::HTTP::Get.new(uri)
+          # リダイレクトをフォローしてレスポンスを取得
+          response = http.request(request)
+          
+          if response.code == '200'
+            parsed_response = JSON.parse(response.body)
+            message = []
           client.reply_message(event['replyToken'], message)
         end
       end

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -8,11 +8,13 @@ class LineBotController < ApplicationController
         case event.type
         when Line::Bot::Event::MessageType::Text
           uri = URI('https://zenn-api.vercel.app/trendTech.json')
+
           # リダイレクトをフォローするための設定
           http = Net::HTTP.new(uri.host, uri.port)
           http.use_ssl = (uri.scheme == 'https')
 
           request = Net::HTTP::Get.new(uri)
+          
           # リダイレクトをフォローしてレスポンスを取得
           response = http.request(request)
           

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -28,6 +28,10 @@ class LineBotController < ApplicationController
               message.push(hash)
             end
           client.reply_message(event['replyToken'], message)
+          else
+            # リクエストが失敗した場合、エラーメッセージを返信
+            client.reply_message(event['replyToken'], [{ type: 'text', text: 'データの取得に失敗しました' }])
+          end
         end
       end
     end

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -19,6 +19,14 @@ class LineBotController < ApplicationController
           if response.code == '200'
             parsed_response = JSON.parse(response.body)
             message = []
+
+            # トレンド上位5記事のみ抽出
+            parsed_response["items"].take(5).each do |item|
+              hash = {}
+              hash[:type] = "text"
+              hash[:text] = item["title"]
+              message.push(hash)
+            end
           client.reply_message(event['replyToken'], message)
         end
       end

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -7,7 +7,7 @@ class LineBotController < ApplicationController
       when Line::Bot::Event::Message
         case event.type
         when Line::Bot::Event::MessageType::Text
-          message = [{type: "text",text: "message 1"}, {type: "text", text: "message 2"}]
+          uri = URI('https://zenn-api.vercel.app/trendTech.json')
           client.reply_message(event['replyToken'], message)
         end
       end

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -8,6 +8,11 @@ class LineBotController < ApplicationController
         case event.type
         when Line::Bot::Event::MessageType::Text
           uri = URI('https://zenn-api.vercel.app/trendTech.json')
+          # リダイレクトをフォローするための設定
+          http = Net::HTTP.new(uri.host, uri.port)
+          http.use_ssl = (uri.scheme == 'https')
+
+          request = Net::HTTP::Get.new(uri)
           client.reply_message(event['replyToken'], message)
         end
       end

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -29,7 +29,7 @@ class LineBotController < ApplicationController
               hash[:text] = item["title"]
               message.push(hash)
             end
-          client.reply_message(event['replyToken'], message)
+            client.reply_message(event['replyToken'], message)
           else
             # リクエストが失敗した場合、エラーメッセージを返信
             client.reply_message(event['replyToken'], [{ type: 'text', text: 'データの取得に失敗しました' }])


### PR DESCRIPTION
## zennのトレンド記事取得のAPIを使用し、トレンド記事上位5記事を返す
- APIのURLを変数uriに格納
- URLのリダイレクト先までアクセスし、レスポンスを取得
- トレンド記事上位5記事のみ抽出
- リクエストが失敗し記事が取得できない場合エラーメッセージを表示する